### PR TITLE
feat: check if the telegram group is already added

### DIFF
--- a/src/activities/telegram/verifyTelegram.ts
+++ b/src/activities/telegram/verifyTelegram.ts
@@ -46,6 +46,15 @@ export async function verifyTelegram(
       // await session.abortTransaction();
       return "Failed. Token doesn't exist.";
     } else {
+      const existingPlatform = await Platform.findOne({
+        name: PlatformNames.Telegram,
+        'metadata.id': chat.id,
+      });
+
+      if (existingPlatform) {
+        return 'This Telegram group has already been added by another admin.';
+      }
+
       const now = new Date();
       const period = new Date();
       period.setDate(now.getDate() - 30);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a check to prevent duplicate Telegram group entries. When an attempt is made to add a Telegram group that has already been managed by another admin, the system now notifies the user and halts further processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->